### PR TITLE
根据 SSL_get_error 返回值区分 SSL_read 返回值为 0 的两种情况.

### DIFF
--- a/async-ssl-svr.cc
+++ b/async-ssl-svr.cc
@@ -191,7 +191,10 @@ void handleDataRead(Channel* ch) {
         return;
     }
     if (rd == 0) {
-        log("No more data to read from socket\n");
+        if (ssle == SSL_ERROR_ZERO_RETURN)
+            log("SSL has been shutdown.\n");
+        else
+            log("Connection has been aborted.\n");
         delete ch;
     }
 }


### PR DESCRIPTION
首先多谢 yedf 的教学代码。

我看了下 openssl doc https://www.openssl.org/docs/manmaster/ssl/SSL_read.html ， 觉得还应继续修改一下。

使用命令 openssl s_client -connect localhost:443 做测试客户端，Ctrl + D 结束可以使服务端 SSL_read 返回 0 并 且 SSL_get_error 返回值 ssle == SSL_ERROR_ZERO_RETURN， Ctrl + C 则 ssle 为其他值。
